### PR TITLE
updated sentry-cocoa to 5.0.0.beta.4. Enabled sessions in AppDelegate

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,6 @@ use_frameworks!
 
 target 'sentry-cocoa' do
 	
-	pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '5.0.0-beta.0'
+	pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '5.0.0-beta.4'
 
 end

--- a/sentry-cocoa/AppDelegate.swift
+++ b/sentry-cocoa/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          _ = SentrySDK(options: [
                "dsn": "https://62340e8b48bd40dbb4382e0d92ad3385@sentry.io/5175254",
                "environment": "Production",
-               
+               "enableAutoSessionTracking": true,
                 // "sampleRate": 0.6
                 //"release": ProcessInfo.processInfo.environment["RELEASE"] //
                 //"debug": true // Enabled debug when first installing is always helpful


### PR DESCRIPTION
Testing steps:
1. pull down the add_release_health branch
2. run pod install to upgrade to the latest version of sentry-cocoa ( should be v5.0.0.beta.4)
3. open the app on an iphone emulator. Close the app without triggering a crash or error. This should have created a session in sentry. 
4. Verify that the session was sent to sentry by going to the release page: https://sentry.io/organizations/testorg-az/releases/?project=5175254&statsPeriod=1h
Crash free users and sessions should both be at 100%
5. Open the app on the same iphone emulator. Cause a crash and open the app again. This should cause a session and a crash to be sent to sentry.
6. Verify that the crash was sent to sentry. Verify that the SDK version is 5.0.0.beta.4
7. Go back to the release page. Verify that the crash count is now 1. Verify that the crash free user is 0% and crash free session is at 50%
8. Open the app on a different iphone emulator. Close the app without triggering an error or crash.
9. Verify that the crash count is still 1. Verify that the crash free user is 50% and crash free session is at 67%
10. On the iphone emulator, trigger a run time error that does not crash the app. Verify that the crash count is still 1. Verify that the crash free user is 50% and crash free session is at 75%